### PR TITLE
Using full exception in ConfigurationInvalidCreatingInstanceFailed

### DIFF
--- a/SimpleInjector.NET/StringResources.cs
+++ b/SimpleInjector.NET/StringResources.cs
@@ -110,7 +110,7 @@ namespace SimpleInjector
         internal static string ConfigurationInvalidCreatingInstanceFailed(Type serviceType, Exception exception) => 
             string.Format(CultureInfo.InvariantCulture,
                 "The configuration is invalid. Creating the instance for type {0} failed. {1}",
-                serviceType.ToFriendlyName(), exception.Message);
+                serviceType.ToFriendlyName(), exception);
 
         internal static string ConfigurationInvalidIteratingCollectionFailed(Type serviceType, Exception exception) => 
             string.Format(CultureInfo.InvariantCulture,


### PR DESCRIPTION
Currently `ConfigurationInvalidCreatingInstanceFailed` includes only the exception message. For cases, such as ArgumentException occurred deep inside service's class tree, it doesn't provide enough information.

For instance, for the code like this:

```csharp
var container = ContainerConfig.CreateContainer();

Action action = () => container.Verify(VerificationOption.VerifyOnly);

action.ShouldNotThrow();
```
The exception would be this:
```
at FluentAssertions.Execution.FallbackTestFramework.Throw(String message) in D:\Workspaces\FluentAssertions\Src\Shared\Execution\FallbackTestFramework.cs:line 21
   at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message) in D:\Workspaces\FluentAssertions\Src\FluentAssertions.Net40\Execution\TestFrameworkProvider.cs:line 42
   at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message) in D:\Workspaces\FluentAssertions\Src\Core\Execution\DefaultAssertionStrategy.cs:line 25
   at FluentAssertions.Execution.AssertionScope.FailWith(String message, Object[] args) in D:\Workspaces\FluentAssertions\Src\Core\Execution\AssertionScope.cs:line 197
   at FluentAssertions.Specialized.ActionAssertions.ShouldNotThrow(String because, Object[] reasonArgs) in D:\Workspaces\FluentAssertions\Src\Core\Specialized\ActionAssertions.cs:line 100
   at FluentAssertions.AssertionExtensions.ShouldNotThrow(Action action, String because, Object[] reasonArgs) in D:\Workspaces\FluentAssertions\Src\Shared\AssertionExtensions.Actions.cs:line 125
   at WebJobs.Tests.ContainerConfigTest.Container_Verify_Should_Not_Throw_Exception() in WebJobs.Tests\ContainerConfigTest.cs:line 21
Result Message:	
FluentAssertions.Execution.AssertionFailedException:
Did not expect any exception, but found System.InvalidOperationException with message "The configuration is invalid. Creating the instance for type IAzureProductProvider failed. Value cannot be null.
Parameter name: authKey"
     at SimpleInjector.InstanceProducer.VerifyInstanceCreation()
     at SimpleInjector.Container.VerifyInstanceCreation(InstanceProducer[] producersToVerify)
     at SimpleInjector.Container.VerifyThatAllRootObjectsCanBeCreated()
     at SimpleInjector.Container.VerifyInternal(Boolean suppressLifestyleMismatchVerification)
     at SimpleInjector.Container.Verify(VerificationOption option)
     at WebJobs.Tests.ContainerConfigTest.<>c__DisplayClass0_0.<Container_Verify_Should_Not_Throw_Exception>b__0() in WebJobs.Tests\ContainerConfigTest.cs:line 18
     at FluentAssertions.Specialized.ActionAssertions.ShouldNotThrow(String because, Object[] reasonArgs) in D:\Workspaces\FluentAssertions\Src\Core\Specialized\ActionAssertions.cs:line 96
```
Particularly:
>The configuration is invalid. Creating the instance for type IAzureProductProvider failed. Value cannot be null.
Parameter name: authKey