### PR TITLE
Check the IsGenericParameter property before invoking the GetGenericParameterConstraints function

### DIFF
--- a/src/SimpleInjector.NET.Tests.Unit/RegisterOpenGenericTests.cs
+++ b/src/SimpleInjector.NET.Tests.Unit/RegisterOpenGenericTests.cs
@@ -1,4 +1,6 @@
-﻿namespace SimpleInjector.Tests.Unit
+﻿using SimpleInjector.Internals;
+
+namespace SimpleInjector.Tests.Unit
 {
     using System;
     using System.Collections.Generic;
@@ -23,6 +25,20 @@
             var impl = container.GetInstance<IService<int, string>>();
 
             AssertThat.IsInstanceOfType(typeof(ServiceImpl<int, string>), impl);
+        }
+
+        [TestMethod]
+        public void BuildClosedGenericImplementationForFluentOpenGeneric_WithValidArguments_ReturnsInvalidResult()
+        {
+            // Assert
+            var genericTypeBuilder = new GenericTypeBuilder(typeof (IFluentServiceFactory<>),
+                typeof (FluentServiceFactory<>));
+
+            // Act
+            var result = genericTypeBuilder.BuildClosedGenericImplementation();
+
+            // Assert
+            Assert.IsFalse(result.ClosedServiceTypeSatisfiesAllTypeConstraints);
         }
 
         [TestMethod]

--- a/src/SimpleInjector.NET.Tests.Unit/TestClasses.OpenGenerics.cs
+++ b/src/SimpleInjector.NET.Tests.Unit/TestClasses.OpenGenerics.cs
@@ -151,4 +151,30 @@
         {
         }
     }
+
+    public interface IFluentServiceFactory<T> where T : IFluentService<T>
+    {
+        T Create();
+    }
+
+    public class FluentServiceFactory<T> : IFluentServiceFactory<T> where T : IFluentService<T>
+    {
+        public T Create()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public interface IFluentService<T> where T : IFluentService<T>
+    {
+        T DoSomething();
+    }
+
+    public class FluentService : IFluentService<FluentService>
+    {
+        public FluentService DoSomething()
+        {
+            return this;
+        }
+    }
 }

--- a/src/SimpleInjector/Internals/TypeConstraintValidator.cs
+++ b/src/SimpleInjector/Internals/TypeConstraintValidator.cs
@@ -87,6 +87,11 @@ namespace SimpleInjector.Internals
 
         private bool ParameterSatisfiesGenericParameterConstraints()
         {
+            if (this.Mapping.Argument.Info().IsGenericParameter == false)
+            {
+                return true;
+            }
+
             var unsatisfiedConstraints =
                 from constraint in this.Mapping.Argument.Info().GetGenericParameterConstraints()
                 where !this.MappingMightBeCompatibleWithTypeConstraint(constraint)
@@ -130,6 +135,10 @@ namespace SimpleInjector.Internals
 
         private bool MappingHasConstraint(GenericParameterAttributes constraint)
         {
+            if (this.Mapping.Argument.IsGenericParameter == false)
+            {
+                return false;
+            }
             var constraints = this.Mapping.Argument.Info().GenericParameterAttributes;
             return (constraints & constraint) != GenericParameterAttributes.None;
         }


### PR DESCRIPTION
Hi

When working with the fluent interfaces the SimpleInjector throws annoying exceptions. It swallows them internally but it still looks bad (and also makes the debugging harder).

I've attached the simple class structure and the test that highlights the problem. 

I'm not familiar with the simple injector code and I didn't find any good place for the GenericTypeBuilder tests so I placed the test into the RegisterOpenGenericTests file.

Cheers,
Demid