### PR TITLE
Only try concrete creation when not an interface

### DIFF
--- a/src/SimpleInjector/Container.Resolving.cs
+++ b/src/SimpleInjector/Container.Resolving.cs
@@ -327,7 +327,7 @@ namespace SimpleInjector
         private InstanceProducer BuildInstanceProducerForType(Type serviceType, 
             bool autoCreateConcreteTypes = true)
         {
-            Func<InstanceProducer> tryBuildInstanceProducerForConcrete = autoCreateConcreteTypes
+            Func<InstanceProducer> tryBuildInstanceProducerForConcrete = autoCreateConcreteTypes && !serviceType.IsInterface
                 ? () => this.TryBuildInstanceProducerForConcreteUnregisteredType(serviceType)
                 : (Func<InstanceProducer>)(() => null);
 


### PR DESCRIPTION
When resolving an interface which has not been registered an activation exception is thrown trying to instantiate as though the interface is a concrete class.
It is possible to handle this earlier, avoiding the exception and reducing the call stack created while resolving.

Before:
![image](https://cloud.githubusercontent.com/assets/10784779/15686714/84146b88-2769-11e6-9dc6-5f6c5883a4ae.png)

After:
![image](https://cloud.githubusercontent.com/assets/10784779/15686815/ccc3117c-2769-11e6-9f0d-36ebcc3bbe6a.png)

Demo code -
```
IServiceProvider container = new Container();
container.GetService(typeof(ICloneable));
```