### PR TITLE
Add support for .NET Standard 2.0

### DIFF
--- a/src/BuildTools/Nuget/.NET/SimpleInjector/SimpleInjector.nuspec
+++ b/src/BuildTools/Nuget/.NET/SimpleInjector/SimpleInjector.nuspec
@@ -26,6 +26,9 @@
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="System.ComponentModel" version="4.0.1" />
       </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.ComponentModel" version="4.0.1" />
+      </group>
     </dependencies>
   </metadata>
 </package>

--- a/src/SimpleInjector/Internals/ReflectionExtensions.cs
+++ b/src/SimpleInjector/Internals/ReflectionExtensions.cs
@@ -50,7 +50,7 @@ namespace SimpleInjector
         public static Assembly GetAssembly(this Type type) => type.Assembly;
         public static Guid GetGuid(this Type type) => type.GUID;
 #endif        
-#if NETSTANDARD1_0 || NETSTANDARD1_3
+#if NETSTANDARD1_0 || NETSTANDARD1_3 || NETSTANDARD2_0
         public static MethodInfo GetSetMethod(this PropertyInfo property, bool nonPublic = true) =>
             nonPublic || property.SetMethod?.IsPublic == true ? property.SetMethod : null;
 

--- a/src/SimpleInjector/Lifestyles/AsyncScopedLifestyle.cs
+++ b/src/SimpleInjector/Lifestyles/AsyncScopedLifestyle.cs
@@ -46,7 +46,7 @@ namespace SimpleInjector.Lifestyles
     /// }
     /// ]]></code>
     /// </example>
-#if NETSTANDARD1_3 || NET45
+#if NETSTANDARD1_3 || NETSTANDARD2_0 || NET45
     public class AsyncScopedLifestyle : ScopedLifestyle
     {
         private static readonly object managerKey = new object();

--- a/src/SimpleInjector/SimpleInjector.csproj
+++ b/src/SimpleInjector/SimpleInjector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>4.0.0</VersionPrefix>
-    <TargetFrameworks>netstandard1.0;netstandard1.3;net40;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0;net40;net45</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SimpleInjector</AssemblyName>
@@ -25,6 +25,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.ComponentModel" Version="4.0.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.ComponentModel" Version="4.0.1" />
   </ItemGroup>
 

--- a/src/build.bat
+++ b/src/build.bat
@@ -192,6 +192,8 @@ IF %step%==4 (
 	copy SimpleInjector\bin\Release\netstandard1.0\SimpleInjector.xml "Releases\temp\lib\netstandard1.0\SimpleInjector.xml"
 	copy SimpleInjector\bin\Release\netstandard1.3\SimpleInjector.dll "Releases\temp\lib\netstandard1.3\SimpleInjector.dll"
 	copy SimpleInjector\bin\Release\netstandard1.3\SimpleInjector.xml "Releases\temp\lib\netstandard1.3\SimpleInjector.xml"
+	copy SimpleInjector\bin\Release\netstandard2.0\SimpleInjector.dll "Releases\temp\lib\netstandard2.0\SimpleInjector.dll"
+	copy SimpleInjector\bin\Release\netstandard2.0\SimpleInjector.xml "Releases\temp\lib\netstandard2.0\SimpleInjector.xml"
 	%replace% /source:Releases\temp\SimpleInjector.nuspec {version} %named_version_Core%
 	%replace% /source:Releases\temp\SimpleInjector.nuspec {year} %copyrightYear%
 	%replace% /source:Releases\temp\package\services\metadata\core-properties\c8082e2254fe4defafc3b452026f048d.psmdcp {version} %named_version_Core%


### PR DESCRIPTION
eliminate NETStandard.Library 1.x dependency to avoid ballooning.  

I went through the build script from start to finish to ensure that everything builds and packages correctly.