### PR TITLE
Remove double negatives

### DIFF
--- a/src/SimpleInjector/Container.Resolving.cs
+++ b/src/SimpleInjector/Container.Resolving.cs
@@ -164,7 +164,7 @@ namespace SimpleInjector
         /// </summary>
         /// <remarks>
         /// <para>
-        /// A call to this method locks the container. No new registrations can't be made after a call to this 
+        /// A call to this method locks the container. New registrations can't be made after a call to this 
         /// method.
         /// </para>
         /// <para>
@@ -190,7 +190,7 @@ namespace SimpleInjector
         /// </summary>
         /// <remarks>
         /// <para>
-        /// A call to this method locks the container. No new registrations can't be made after a call to this 
+        /// A call to this method locks the container. New registrations can't be made after a call to this 
         /// method.
         /// </para>
         /// <para>

--- a/src/SimpleInjector/InstanceProducer.cs
+++ b/src/SimpleInjector/InstanceProducer.cs
@@ -283,7 +283,7 @@ namespace SimpleInjector
 
         /// <summary>
         /// Builds an expression that expresses the intent to get an instance by the current producer. A call 
-        /// to this method locks the container. No new registrations can't be made after a call to this method.
+        /// to this method locks the container. New registrations can't be made after a call to this method.
         /// </summary>
         /// <returns>An Expression.</returns>
         public Expression BuildExpression()


### PR DESCRIPTION
I considered changing the wording to 

> No new registrations _**may**_ be made ...

But this wording is closer to other comments used.