### PR TITLE
Add information about lifestyles to VisualizeObjectGraph

### DIFF
--- a/src/SimpleInjector.Tests.Unit/InstanceProducerTests.cs
+++ b/src/SimpleInjector.Tests.Unit/InstanceProducerTests.cs
@@ -115,11 +115,7 @@
         FakeTimeProvider(), // Transient
         PluginDecorator<Int32>( // Transient
             PluginWithDependencyOfType<RealTimeProvider>( // Transient
-                RealTimeProvider() // Transient
-            )
-        )
-    )
-)";
+                RealTimeProvider())))) // Transient";
 
             var container = ContainerFactory.New();
 
@@ -150,11 +146,7 @@
         FakeTimeProvider(), // Transient
         PluginDecorator<Int32>( // Transient
             PluginWithDependencyOfType<RealTimeProvider>( // Transient
-                RealTimeProvider() // Transient
-            )
-        )
-    )
-)";
+                RealTimeProvider())))) // Transient";
 
             var container = ContainerFactory.New();
 
@@ -188,11 +180,7 @@
         FakeTimeProvider(),
         PluginDecorator<Int32>(
             PluginWithDependencyOfType<RealTimeProvider>(
-                RealTimeProvider()
-            )
-        )
-    )
-)";
+                RealTimeProvider()))))";
 
             var container = ContainerFactory.New();
 
@@ -244,10 +232,7 @@
 @"InstanceProducerTests.NodeFactory( // Transient
     IEnumerable<InstanceProducerTests.INode>( // Singleton
         InstanceProducerTests.NodeFactory( // Transient
-            IEnumerable<InstanceProducerTests.INode>(/* cyclic dependency graph detected */)
-        )
-    )
-)";
+            IEnumerable<InstanceProducerTests.INode>(/* cyclic dependency graph detected */)))) // Singleton";
 
             var container = new Container();
 
@@ -273,18 +258,13 @@
         {
             // Arrange
             string expectedObjectGraph =
-@"PluginWithDependencies<PluginWithDependencyOfType<PluginWithDependencyOfType<RealTimeProvider>>, ServiceDependingOn<PluginWithDependencyOfType<RealTimeProvider>>>(
-    PluginWithDependencyOfType<PluginWithDependencyOfType<RealTimeProvider>>(
-        PluginWithDependencyOfType<RealTimeProvider>(
-            RealTimeProvider()
-        )
-    ),
-    ServiceDependingOn<PluginWithDependencyOfType<RealTimeProvider>>(
-        PluginWithDependencyOfType<RealTimeProvider>(
-            RealTimeProvider()
-        )
-    )
-)";
+@"PluginWithDependencies<PluginWithDependencyOfType<PluginWithDependencyOfType<RealTimeProvider>>, ServiceDependingOn<PluginWithDependencyOfType<RealTimeProvider>>>( // Transient
+    PluginWithDependencyOfType<PluginWithDependencyOfType<RealTimeProvider>>( // Transient
+        PluginWithDependencyOfType<RealTimeProvider>( // Transient
+            RealTimeProvider())), // Transient
+    ServiceDependingOn<PluginWithDependencyOfType<RealTimeProvider>>( // Transient
+        PluginWithDependencyOfType<RealTimeProvider>( // Transient
+            RealTimeProvider()))) // Transient";
 
             var container = ContainerFactory.New();
 
@@ -297,7 +277,7 @@
             // Act
             string actualObjectGraph = pluginProducer.VisualizeObjectGraph(new VisualizationOptions
             {
-                IncludeLifestyleInformation = false,
+                IncludeLifestyleInformation = true,
             });
 
             // Assert

--- a/src/SimpleInjector/InstanceProducer.cs
+++ b/src/SimpleInjector/InstanceProducer.cs
@@ -362,16 +362,13 @@ namespace SimpleInjector
         /// <see cref="GetInstance"/> or <see cref="BuildExpression"/> on an instance that depends on this
         /// instance, or by calling <see cref="SimpleInjector.Container.Verify()">Verify</see> on the container.
         /// </exception>
-        public string VisualizeObjectGraph() => this.VisualizeObjectGraph(new VisualizationOptions
-        {
-            IncludeLifestyleInformation = false,
-        }); // backwards compatible.
+        public string VisualizeObjectGraph() => this.VisualizeObjectGraph(new VisualizationOptions());
 
         /// <summary>
         /// Builds a string representation of the object graph with the current instance as root of the
         /// graph.
         /// </summary>
-        /// <param name="options"></param>
+        /// <param name="options">The various visualization options for building a string representation of the object graph.</param>
         /// <returns>A string representation of the object graph.</returns>
         /// <exception cref="InvalidOperationException">Thrown when this method is called before 
         /// <see cref="GetInstance"/> or <see cref="BuildExpression"/> have been called. These calls can be
@@ -696,10 +693,7 @@ namespace SimpleInjector
             // graph to be shown in compact form in the debugger in-line value field, but still allow the
             // complete formatted object graph to be shown when the user opens the text visualizer.
             [DebuggerDisplay(value: "{" + nameof(TruncatedDependencyGraph) + ", nq}")]
-            public string DependencyGraph => this.producer.VisualizeIndentedObjectGraph(new VisualizationOptions
-            {
-                IncludeLifestyleInformation = true,
-            });
+            public string DependencyGraph => this.producer.VisualizeIndentedObjectGraph(new VisualizationOptions());
 
             [DebuggerHidden]
             private string TruncatedDependencyGraph => this.producer.VisualizeInlinedAndTruncatedObjectGraph(160);

--- a/src/SimpleInjector/InstanceProducer.cs
+++ b/src/SimpleInjector/InstanceProducer.cs
@@ -362,15 +362,35 @@ namespace SimpleInjector
         /// <see cref="GetInstance"/> or <see cref="BuildExpression"/> on an instance that depends on this
         /// instance, or by calling <see cref="SimpleInjector.Container.Verify()">Verify</see> on the container.
         /// </exception>
-        public string VisualizeObjectGraph()
+        public string VisualizeObjectGraph() => this.VisualizeObjectGraph(new VisualizationOptions
         {
+            IncludeLifestyleInformation = false,
+        }); // backwards compatible.
+
+        /// <summary>
+        /// Builds a string representation of the object graph with the current instance as root of the
+        /// graph.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns>A string representation of the object graph.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when this method is called before 
+        /// <see cref="GetInstance"/> or <see cref="BuildExpression"/> have been called. These calls can be
+        /// done directly and explicitly by the user on this instance, indirectly by calling
+        /// <see cref="GetInstance"/> or <see cref="BuildExpression"/> on an instance that depends on this
+        /// instance, or by calling <see cref="SimpleInjector.Container.Verify()">Verify</see> on the container.
+        /// </exception>
+        /// <exception cref="NullReferenceException">Thrown when options is null.</exception>
+        public string VisualizeObjectGraph(VisualizationOptions options)
+        {
+            Requires.IsNotNull(options, nameof(options));
+
             if (!this.IsExpressionCreated)
             {
                 throw new InvalidOperationException(
                     StringResources.VisualizeObjectGraphShouldBeCalledAfterTheExpressionIsCreated());
             }
 
-            return InstanceProducerVisualizer.VisualizeIndentedObjectGraph(this);
+            return InstanceProducerVisualizer.VisualizeIndentedObjectGraph(this, options);
         }
 
         // Throws an InvalidOperationException on failure.
@@ -676,7 +696,10 @@ namespace SimpleInjector
             // graph to be shown in compact form in the debugger in-line value field, but still allow the
             // complete formatted object graph to be shown when the user opens the text visualizer.
             [DebuggerDisplay(value: "{" + nameof(TruncatedDependencyGraph) + ", nq}")]
-            public string DependencyGraph => this.producer.VisualizeIndentedObjectGraph();
+            public string DependencyGraph => this.producer.VisualizeIndentedObjectGraph(new VisualizationOptions
+            {
+                IncludeLifestyleInformation = true,
+            });
 
             [DebuggerHidden]
             private string TruncatedDependencyGraph => this.producer.VisualizeInlinedAndTruncatedObjectGraph(160);

--- a/src/SimpleInjector/Internals/InstanceProducerVisualizer.cs
+++ b/src/SimpleInjector/Internals/InstanceProducerVisualizer.cs
@@ -69,9 +69,9 @@ namespace SimpleInjector.Internals
             objectGraphBuilder.BeginInstanceProducer(producer);
 
             var dependencies = producer
-                                .GetRelationships()
-                                .Select(relationship => relationship.Dependency)
-                                .ToList();
+                .GetRelationships()
+                .Select(relationship => relationship.Dependency)
+                .ToList();
 
             for (int counter = 0; counter < dependencies.Count; counter++)
             {

--- a/src/SimpleInjector/Internals/ObjectGraphBuilder.cs
+++ b/src/SimpleInjector/Internals/ObjectGraphBuilder.cs
@@ -1,13 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿#region Copyright Simple Injector Contributors
+/* The Simple Injector is an easy-to-use Inversion of Control library for .NET
+ * 
+ * Copyright (c) 2013 - 2015 Simple Injector Contributors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+ * associated documentation files (the "Software"), to deal in the Software without restriction, including 
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ * copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the 
+ * following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial 
+ * portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO 
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE 
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+#endregion
 
 namespace SimpleInjector.Internals
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
     internal sealed class ObjectGraphBuilder
     {
-        private readonly StringBuilder builder = new StringBuilder(100);
+        private readonly StringBuilder builder = new StringBuilder();
         private readonly Stack<ProducerEntry> producers = new Stack<ProducerEntry>();
         private readonly bool writeLifestyles;
 
@@ -23,7 +45,7 @@ namespace SimpleInjector.Internals
 
         internal void BeginInstanceProducer(InstanceProducer producer)
         {
-            if (this.producers.Any())
+            if (this.producers.Count > 0)
             {
                 this.AppendLifestyle(this.producers.Peek());
                 this.AppendNewLine();

--- a/src/SimpleInjector/Internals/ObjectGraphBuilder.cs
+++ b/src/SimpleInjector/Internals/ObjectGraphBuilder.cs
@@ -77,7 +77,6 @@ namespace SimpleInjector.Internals
             if (!last)
             {
                 this.Append(",");
-
                 if (this.stillToWriteLifestyleEntry != null)
                 {
                     this.AppendLifestyle(this.stillToWriteLifestyleEntry);
@@ -116,7 +115,7 @@ namespace SimpleInjector.Internals
         private void AppendIndent()
         {
             const string INDENT = "    ";
-            for (int i = 0; i < indentingDepth; i++)
+            for (int i = 0; i < this.indentingDepth; i++)
             {
                 this.Append(INDENT);
             }

--- a/src/SimpleInjector/Internals/ObjectGraphBuilder.cs
+++ b/src/SimpleInjector/Internals/ObjectGraphBuilder.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SimpleInjector.Internals
+{
+    internal sealed class ObjectGraphBuilder
+    {
+        private readonly StringBuilder builder = new StringBuilder(100);
+        private readonly Stack<ProducerEntry> producers = new Stack<ProducerEntry>();
+        private readonly bool writeLifestyles;
+
+        private ProducerEntry stillToWriteLifestyleEntry;
+        private int indentingDepth;
+
+        public ObjectGraphBuilder(bool writeLifestyles)
+        {
+            this.writeLifestyles = writeLifestyles;
+        }
+
+        public override string ToString() => this.builder.ToString();
+
+        internal void BeginInstanceProducer(InstanceProducer producer)
+        {
+            if (this.producers.Any())
+            {
+                this.AppendLifestyle(this.producers.Peek());
+                this.AppendNewLine();
+            }
+
+            this.producers.Push(new ProducerEntry(producer));
+
+            this.Append(producer.ImplementationType.ToFriendlyName());
+            this.Append("(");
+
+            this.indentingDepth++;
+        }
+
+        internal void AppendCyclicInstanceProducer(InstanceProducer producer, bool last)
+        {
+            this.BeginInstanceProducer(producer);
+            this.Append("/* cyclic dependency graph detected */");
+            this.EndInstanceProducer(last);
+        }
+
+        internal void EndInstanceProducer(bool last)
+        {
+            var entry = this.producers.Pop();
+
+            this.indentingDepth--;
+
+            this.Append(")");
+
+            if (!last)
+            {
+                this.Append(",");
+
+                if (this.stillToWriteLifestyleEntry != null)
+                {
+                    this.AppendLifestyle(this.stillToWriteLifestyleEntry);
+                    this.stillToWriteLifestyleEntry = null;
+                }
+                this.AppendLifestyle(entry);
+            }
+
+            if (!entry.LifestyleWritten)
+            {
+                this.stillToWriteLifestyleEntry = entry;
+            }
+
+            if (!this.producers.Any())
+            {
+                this.AppendLifestyle(this.stillToWriteLifestyleEntry);
+            }
+        }
+
+        private void AppendNewLine()
+        {
+            this.Append(Environment.NewLine);
+            this.AppendIndent();
+        }
+
+        private void AppendLifestyle(ProducerEntry entry)
+        {
+            if (this.writeLifestyles && !entry.LifestyleWritten)
+            {
+                this.Append(" // ");
+                this.Append(entry.Producer.Lifestyle.Name);
+                entry.LifestyleWritten = true;
+            }
+        }
+
+        private void AppendIndent()
+        {
+            const string INDENT = "    ";
+            for (int i = 0; i < indentingDepth; i++)
+            {
+                this.Append(INDENT);
+            }
+        }
+
+        private void Append(string value) => this.builder.Append(value);
+
+        private sealed class ProducerEntry
+        {
+            public ProducerEntry(InstanceProducer producer)
+            {
+                this.Producer = producer;
+            }
+
+            public InstanceProducer Producer { get; }
+            public bool LifestyleWritten { get; set; }
+        }
+    }
+}

--- a/src/SimpleInjector/VisualizationOptions.cs
+++ b/src/SimpleInjector/VisualizationOptions.cs
@@ -28,8 +28,9 @@ namespace SimpleInjector
     public class VisualizationOptions
     {
         /// <summary>
-        /// Gets or sets the value indicating whether to include lifestyle information in the visualization.
+        /// Gets or sets a value indicating whether to include lifestyle information in the visualization.
         /// </summary>
+        /// <value>The value to include life style information.</value>
         public bool IncludeLifestyleInformation { get; set; } = true;
     }
 }

--- a/src/SimpleInjector/VisualizationOptions.cs
+++ b/src/SimpleInjector/VisualizationOptions.cs
@@ -6,7 +6,7 @@
     public class VisualizationOptions
     {
         /// <summary>
-        /// Include lifestyle information in the visualization.
+        /// Gets or sets the value indicating whether to include lifestyle information in the visualization.
         /// </summary>
         public bool IncludeLifestyleInformation { get; set; } = true;
     }

--- a/src/SimpleInjector/VisualizationOptions.cs
+++ b/src/SimpleInjector/VisualizationOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace SimpleInjector
+{
+    /// <summary>
+    /// Visualization options for providing various information about instances.
+    /// </summary>
+    public class VisualizationOptions
+    {
+        /// <summary>
+        /// Include lifestyle information in the visualization.
+        /// </summary>
+        public bool IncludeLifestyleInformation { get; set; } = true;
+    }
+}

--- a/src/SimpleInjector/VisualizationOptions.cs
+++ b/src/SimpleInjector/VisualizationOptions.cs
@@ -1,4 +1,26 @@
-﻿namespace SimpleInjector
+﻿#region Copyright Simple Injector Contributors
+/* The Simple Injector is an easy-to-use Inversion of Control library for .NET
+ * 
+ * Copyright (c) 2013 Simple Injector Contributors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+ * associated documentation files (the "Software"), to deal in the Software without restriction, including 
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ * copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the 
+ * following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial 
+ * portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO 
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE 
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+#endregion
+
+namespace SimpleInjector
 {
     /// <summary>
     /// Visualization options for providing various information about instances.


### PR DESCRIPTION
First implementation to add information about lifestyles to VisualizeObjectGraph.

Todo:
- [x] Fix failing continuous-integration build => Known issue. Fix another time.
- [x] Fix failing unittest(s) on local development machine Memorytest.CreatingManyContainers_WithNoRegistrations_DoesNotIncreaseMemoryFootprint
- [x] Write documentation for Simple Injector website?
- [x] Design: Should current VisualizeObjectGraph be backwards compatible? Or should we add the lifestyle information as default?
- [x] Design: What for options should the property "DependencyGraph" use? With or without IncludeLifeStyleInformation?
- [x] Design: Should we use some sort of a builder/formatter that use the new options to format an output string  in line 74 of InstanceProducerVisualizer?

Any code review or suggestions ?