### PR TITLE
Add a non-generic call for UseMiddleware

### DIFF
--- a/src/SimpleInjector.Integration.AspNetCore/Requires.cs
+++ b/src/SimpleInjector.Integration.AspNetCore/Requires.cs
@@ -17,9 +17,9 @@ namespace SimpleInjector
 
         internal static void IsOfType<ShouldBeType>(Type type,string paramName)
         {
-            if ( !(type.IsSubclassOf(typeof(ShouldBeType) ) ))
+            if (!(typeof(ShouldBeType).IsAssignableFrom(type)))
             {
-                throw new ArgumentException($"{paramName} should be of type {nameof(ShouldBeType)}");
+                throw new ArgumentException($"{paramName} should be of type {typeof(ShouldBeType).Name}");
             }
         }
     }

--- a/src/SimpleInjector.Integration.AspNetCore/Requires.cs
+++ b/src/SimpleInjector.Integration.AspNetCore/Requires.cs
@@ -14,5 +14,13 @@ namespace SimpleInjector
                 throw new ArgumentNullException(paramName);
             }
         }
+
+        internal static void IsOfType<ShouldBeType>(Type type,string paramName)
+        {
+            if ( !(type.IsSubclassOf(typeof(ShouldBeType) ) ))
+            {
+                throw new ArgumentException($"{paramName} should be of type {nameof(ShouldBeType)}");
+            }
+        }
     }
 }


### PR DESCRIPTION
This check would allow me to call UseMiddleware like this:
```cs
            app.UseSimpleInjector(_container, options =>
            {
                foreach (var middleware in middlewares)
                {
                    options.UseMiddleware(middleware.GetType(), app);
                }
                //Can also register Middleware here
                options.UseLogging();
            });

```

This is because I want to abstract away where I do this code to simplify my startup.cs file. This will be put in a class that I wouldn't want to aware of my middlewares at compile time.