### PR TITLE
Fixed issue to allow conditionally different instances of the same type services #836

### DIFF
--- a/src/SimpleInjector.Tests.Unit/RegisterConditionalTests.cs
+++ b/src/SimpleInjector.Tests.Unit/RegisterConditionalTests.cs
@@ -1929,6 +1929,25 @@
             Assert.AreEqual(2.0, doubleValue);
         }
 
+        // #836
+        interface IFoo { }
+        class Foo : IFoo { public bool Debug { get; set; } }
+
+        [TestMethod]
+        public void RegisteringConditional_WithDifferentInstancesOfSameTypeForSameService_Succeeds()
+        {
+            // Arrange
+            var container = new Container();
+
+            container.RegisterConditional<IFoo>(
+                Lifestyle.Singleton.CreateRegistration(typeof(IFoo), new Foo { }, container),
+                c => c.Consumer.Target.Name.StartsWith("debug", StringComparison.Ordinal));
+
+            container.RegisterConditional<IFoo>(
+                Lifestyle.Singleton.CreateRegistration(typeof(IFoo), new Foo { Debug = true }, container),
+                c => !c.Handled);
+        }
+
         private static void RegisterConditionalConstant<T>(Container container, T constant,
             Predicate<PredicateContext> predicate)
         {

--- a/src/SimpleInjector/Internals/NonGenericRegistrationEntry.cs
+++ b/src/SimpleInjector/Internals/NonGenericRegistrationEntry.cs
@@ -157,6 +157,8 @@ namespace SimpleInjector.Internals
             where producer.FinalImplementationType != null
             where !producer.Registration.WrapsInstanceCreationDelegate
             where !producerToRegister.Registration.WrapsInstanceCreationDelegate
+            where !producer.Registration.ResolvesExternallyOwnedInstance
+            where !producerToRegister.Registration.ResolvesExternallyOwnedInstance
             where producer.FinalImplementationType == producerToRegister.FinalImplementationType
             select producer;
 

--- a/src/SimpleInjector/Lifestyles/SingletonLifestyle.cs
+++ b/src/SimpleInjector/Lifestyles/SingletonLifestyle.cs
@@ -163,6 +163,8 @@ namespace SimpleInjector.Lifestyles
                 this.ServiceType = serviceType;
             }
 
+            internal override bool ResolvesExternallyOwnedInstance => true;
+
             public Type ServiceType { get; }
 
             public override Expression BuildExpression() =>

--- a/src/SimpleInjector/Registration.cs
+++ b/src/SimpleInjector/Registration.cs
@@ -97,6 +97,8 @@ namespace SimpleInjector
 
         internal virtual bool MustBeVerified => false;
 
+        internal virtual bool ResolvesExternallyOwnedInstance => false;
+
         /// <summary>Gets or sets a value indicating whether this registration object contains a user
         /// supplied instanceCreator factory delegate.</summary>
         internal bool WrapsInstanceCreationDelegate { get; set; }


### PR DESCRIPTION
Allow different instances of same types using conditionally register.

By introducing a new property ResolvesExternallyOwnedInstance on Registration class, we can remove all the externally owned instances  from the validation of the registrations.