### PR TITLE
Enable source link support. #884

### DIFF
--- a/src/SimpleInjector/SimpleInjector.csproj
+++ b/src/SimpleInjector/SimpleInjector.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>5.0.0</VersionPrefix>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
@@ -21,6 +21,10 @@
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
@@ -47,5 +51,13 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.Github" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
These are the changes which are required for source link. (https://github.com/simpleinjector/SimpleInjector/issues/884)
For information about the properties, see https://github.com/dotnet/sourcelink/blob/master/docs/README.md

I can rename the `$(GITHUB_ACTIONS)` variable, since you do not use Github_Actions or any other CI system.
How do you publish SimpleInjector? Locally from your PC?

When using dotnet pack, the following packages are created:
 - SimpleInjector.[version].nupkg
 - Simpleinjector.[version].snupkg

You can open SimpleInjector.[version].nupkg in Nuget Package explorer.
Notice the difference between the new package (left) and the old (right). Lots of green checks indicating that everything is ok.
✔

![image](https://user-images.githubusercontent.com/338856/104477270-2f90cd00-55c1-11eb-85af-20a2cc91f9d9.png)

More important, stepping into SimpleInjector source is now possible 🤘

![image](https://user-images.githubusercontent.com/338856/104477377-50f1b900-55c1-11eb-9ca5-0161eb316884.png)

Thats all :-) 